### PR TITLE
Implement eeprom writing in eepromCmdFnc

### DIFF
--- a/Firmware/OpenSteamController/src/eeprom_access.c
+++ b/Firmware/OpenSteamController/src/eeprom_access.c
@@ -158,8 +158,9 @@ int eepromCmdFnc(int argc, const char* argv[]) {
 		uint32_t num_words = strtol(argv[4], NULL, 0);
 		retval = eepromReadToConsole(word_size, addr, num_words);
 	} else if (!strcmp("write", argv[1])) {
-		//TODO: imeplement this
-		printf("eeprom writing not implemented yet\n");
+		printf("experimental eeprom write\n");
+		uint32_t arr[1] = { strtol(argv[4], NULL, 16) };
+		eepromWrite(addr, arr, 1);
 		return -1;
 	} else {
 		printf("Invalid argument \"%s\"\n", argv[1]);


### PR DESCRIPTION
Allows the use of eepromCmdFnc to write to the eeprom. 
Writes the 2 digit hex code into eeprom.

Example usage:
eeprom write 8 0x826 72
which would write the value of 114 (hex 72) into eeprom memory location 0x826.
Read back with
eeprom read 8 0x826 1 to see the changed value

![terminal output](https://user-images.githubusercontent.com/1441365/75004809-39e22f80-5421-11ea-88e2-dc1b31c92dbf.png)
